### PR TITLE
remove trailing slash for proxy

### DIFF
--- a/ui-js/package.json
+++ b/ui-js/package.json
@@ -51,5 +51,5 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:7575/"
+  "proxy": "http://localhost:7575"
 }

--- a/ui-ts/package.json
+++ b/ui-ts/package.json
@@ -59,5 +59,5 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:7575/"
+  "proxy": "http://localhost:7575"
 }


### PR DESCRIPTION
The proxy value seems to be sent as the `origin` header to the JSON API, which (rightfully) balks at its trailing slash.

See [the public forum](https://discuss.daml.com/t/daml-ui-template-error/499/9) for more details.