### PR TITLE
bump sdk version

### DIFF
--- a/daml.yaml
+++ b/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 1.17.1
+sdk-version: 2.2.0
 name: daml-ui-template
 source: daml
 parties:

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 1.15.0
+sdk-version: 1.17.1
 name: daml-ui-template
 source: daml
 parties:


### PR DESCRIPTION
Right now `daml start` fails on M1 mac with this error : 
```
Caused by: java.lang.Exception: No native library is found for os.name=Mac and os.arch=aarch64. path=/org/sqlite/native/Mac/aarch64
```